### PR TITLE
Updated workflow for lack of license runs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,11 +60,17 @@ jobs:
           cd DualCore
           cbuild HelloWorld.csolution.yml --packs --update-rte --toolchain ${{ matrix.compiler }}
 
-      - name: SimpleTrustZone
-        if: always()
+      - name: SimpleTrustZone Build and Run 
+        if: ${{ env.ARM_UBL_ACTIVATION_CODE }}
         run: |
           cd SimpleTrustZone
           ./build.py --verbose -c ${{ matrix.compiler }} build run
+
+      - name: SimpleTrustZone Build only
+        if: always()
+        run: |
+          cd SimpleTrustZone
+          ./build.py --verbose -c ${{ matrix.compiler}} build
           
 
       - name: Deactivate Arm tool license

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,7 +67,7 @@ jobs:
           ./build.py --verbose -c ${{ matrix.compiler}} build
 
       - name: SimpleTrustZone Run 
-        if: ${{ env.ARM_UBL_ACTIVATION_CODE }} && always
+        if: ${{ env.ARM_UBL_ACTIVATION_CODE && always() }}
         run: |
           cd SimpleTrustZone
           ./build.py --verbose -c ${{ matrix.compiler }} run

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,7 +61,7 @@ jobs:
           cbuild HelloWorld.csolution.yml --packs --update-rte --toolchain ${{ matrix.compiler }}
 
       - name: SimpleTrustZone Build and Run 
-        if: ${{ env.ARM_UBL_ACTIVATION_CODE }}
+        if: ${{ env.ARM_UBL_ACTIVATION_CODE }} && always
         run: |
           cd SimpleTrustZone
           ./build.py --verbose -c ${{ matrix.compiler }} build run

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,7 +66,7 @@ jobs:
           cd SimpleTrustZone
           ./build.py --verbose -c ${{ matrix.compiler}} build
 
-      - name: SimpleTrustZone Build and Run 
+      - name: SimpleTrustZone Run 
         if: ${{ env.ARM_UBL_ACTIVATION_CODE }} && always
         run: |
           cd SimpleTrustZone

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,17 +60,17 @@ jobs:
           cd DualCore
           cbuild HelloWorld.csolution.yml --packs --update-rte --toolchain ${{ matrix.compiler }}
 
-      - name: SimpleTrustZone Build and Run 
-        if: ${{ env.ARM_UBL_ACTIVATION_CODE }} && always
-        run: |
-          cd SimpleTrustZone
-          ./build.py --verbose -c ${{ matrix.compiler }} build run
-
       - name: SimpleTrustZone Build only
         if: always()
         run: |
           cd SimpleTrustZone
           ./build.py --verbose -c ${{ matrix.compiler}} build
+
+      - name: SimpleTrustZone Build and Run 
+        if: ${{ env.ARM_UBL_ACTIVATION_CODE }} && always
+        run: |
+          cd SimpleTrustZone
+          ./build.py --verbose -c ${{ matrix.compiler }} run
           
 
       - name: Deactivate Arm tool license


### PR DESCRIPTION
The workflow was failing if there was no license available when creating new forks of the repo hindering the CI process. 