### PR TITLE
Remove `outdir` customization

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,8 +6,8 @@
             "type": "arm-debugger",
             "request": "launch",           
             "programs": [
-                "${workspaceFolder}/SimpleTrustZone/out/AVH/CM33_ns.axf",
-                "${workspaceFolder}/SimpleTrustZone/out/AVH/CM33_s.axf"
+                "${workspaceFolder}/SimpleTrustZone/out/CM33_ns/AVH/Debug/CM33_ns.axf",
+                "${workspaceFolder}/SimpleTrustZone/out/CM33_s/AVH/Debug/CM33_s.axf"
             ],
             "programMode": "ram",
             // armdbg --cdb-list
@@ -21,8 +21,8 @@
             "type": "arm-debugger",
             "request": "launch",           
             "programs": [
-                "${workspaceFolder}/SimpleTrustZone/out/AVH/CM33_ns.elf",
-                "${workspaceFolder}/SimpleTrustZone/out/AVH/CM33_s.elf"
+                "${workspaceFolder}/SimpleTrustZone/out/CM33_ns/AVH/Debug/CM33_ns.elf",
+                "${workspaceFolder}/SimpleTrustZone/out/CM33_s/AVH/Debug/CM33_s.elf"
             ],
             "programMode": "ram",
             // armdbg --cdb-list

--- a/DualCore/HelloWorld.csolution.yml
+++ b/DualCore/HelloWorld.csolution.yml
@@ -21,9 +21,6 @@ solution:
       debug: off
       optimize: balanced
 
-  output-dirs:
-    outdir: ./out/$TargetType$/
-
   projects:
     - project: ./cm0plus/HelloWorld_cm0plus.cproject.yml
     - project: ./cm4/HelloWorld_cm4.cproject.yml

--- a/Hello/Hello.csolution.yml
+++ b/Hello/Hello.csolution.yml
@@ -23,8 +23,5 @@ solution:
       debug: off
       optimize: balanced
 
-  output-dirs:
-    outdir: ./out/$TargetType$/
-
   projects:                                   # list related projects
     - project: ./Hello.cproject.yml

--- a/SimpleTrustZone/README.md
+++ b/SimpleTrustZone/README.md
@@ -27,7 +27,7 @@ Variables used in this application can be viewed in the uVision Debugger Watch w
 ## Run in Fast Models
 
 ```txt
-> FVP_MPS2_Cortex-M33 -f model_config.txt -a cpu0=out/AVH/CM33_ns.axf -a cpu0=out/AVH/CM33_s.axf 
+> FVP_MPS2_Cortex-M33 -f model_config.txt -a cpu0=out/CM33_ns/AVH/Debug/CM33_ns.axf -a cpu0=out/CM33_s/AVH/Debug/CM33_s.axf 
 telnetterminal0: Listening for serial connection on port 5000
 telnetterminal1: Listening for serial connection on port 5001
 telnetterminal2: Listening for serial connection on port 5002

--- a/SimpleTrustZone/SimpleTZ.csolution.yml
+++ b/SimpleTrustZone/SimpleTZ.csolution.yml
@@ -19,9 +19,6 @@ solution:
       debug: off
       optimize: balanced
 
-  output-dirs:
-    outdir: ./out/$TargetType$/
-
   projects:
     - project: ./CM33_s/CM33_s.cproject.yml
     - project: ./CM33_ns/CM33_ns.cproject.yml

--- a/SimpleTrustZone/build.py
+++ b/SimpleTrustZone/build.py
@@ -68,8 +68,8 @@ def cbuild(config):
 @matrix_command()
 def model_exec(config):
     return ["FVP_MPS2_Cortex-M33", "-q", "--simlimit", 100, "-f", "model_config.txt",
-            "-a", f"out/AVH/CM33_ns.{config.compiler.image_ext}",
-            "-a", f"out/AVH/CM33_s.{config.compiler.image_ext}"]
+            "-a", f"out/CM33_ns/AVH/Debug/CM33_ns.{config.compiler.image_ext}",
+            "-a", f"out/CM33_s/AVH/Debug/CM33_s.{config.compiler.image_ext}"]
 
 
 @matrix_filter


### PR DESCRIPTION
The customization of the output directory in the form of `outdir: ./out/$TargetType$/` in solutions with multiple `BuildTypes` leads to build conflicts.
The problem becomes evident when generating CMakeLists at solution level encompassing such conflicting contexts: build systems such as `ninja` do not accept multiple identical target rules:
```
ninja: error: build.ninja: multiple rules generate csolution-examples/DualCore/out/FRDM-K32L3A6/HelloWorld_cm0plus.axf
```