### PR TITLE
Added GitHub actions/setup-python@v6 for using the avh-fvp models ver…

### DIFF
--- a/.ci/vcpkg-configuration.json
+++ b/.ci/vcpkg-configuration.json
@@ -7,12 +7,12 @@
     }
   ],
   "requires": {
-    "arm:tools/open-cmsis-pack/cmsis-toolbox": "^2.5.0",
-    "arm:tools/kitware/cmake": "^3.28.4",
-    "arm:tools/ninja-build/ninja": "^1.12.0",
-    "arm:compilers/arm/armclang": "^6.22.0",
-    "arm:compilers/arm/arm-none-eabi-gcc": "^13.2.1",
+    "arm:tools/open-cmsis-pack/cmsis-toolbox": "^2.13.0",
+    "arm:tools/kitware/cmake": "^3.31.5",
+    "arm:tools/ninja-build/ninja": "^1.13.2",
+    "arm:compilers/arm/armclang": "^6.24.0",
+    "arm:compilers/arm/arm-none-eabi-gcc": "^14.2.1",
     "arm:compilers/arm/llvm-embedded": "^20.1.0",
-    "arm:models/arm/avh-fvp": "^11.26.11"
+    "arm:models/arm/avh-fvp": "^11.31.28"
   }
 }

--- a/.github/workflows/Hello-CI.yml
+++ b/.github/workflows/Hello-CI.yml
@@ -46,6 +46,11 @@ jobs:
       - name: Activate Arm tool license
         uses: ARM-software/cmsis-actions/armlm@75fd924d583d17eacdbfaf77f21ca09e335c3c79 # v1
 
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.13'
+
       - name: Build Hello with ${{ matrix.toolchain }}
         working-directory: ./Hello/
         run: |

--- a/.github/workflows/SimpleTZ-CI.yml
+++ b/.github/workflows/SimpleTZ-CI.yml
@@ -41,6 +41,11 @@ jobs:
       - name: Activate Arm tool license
         uses: ARM-software/cmsis-actions/armlm@v1
 
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.13'
+
       - name: Build project CM33_s and CM33_ns for build-type ${{ matrix.build.type }} with ${{ matrix.compiler.name }}
         working-directory: ./SimpleTrustZone/
         run: cbuild SimpleTZ.csolution.yml --packs --context .${{ matrix.build.type }}+AVH --toolchain ${{ matrix.compiler.name }}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-[![License: Apache-2.0](https://img.shields.io/badge/License-Apache--2.0-green?label)](https://github.com/Open-CMSIS-Pack/csolution-examples/blob/main/LICENSE-Apache-2.0)
-[![License: BSD-3-Clause](https://img.shields.io/badge/License-BSD--3--Clause-green?label)](https://github.com/Open-CMSIS-Pack/csolution-examples/blob/main/LICENSE-BSD-3-Clause)
+[![License: Apache-2.0](https://img.shields.io/badge/License-Apache--2.0-green?label=License)](https://github.com/Open-CMSIS-Pack/csolution-examples/blob/main/LICENSE-Apache-2.0)
+[![License: BSD-3-Clause](https://img.shields.io/badge/License-BSD--3--Clause-green?label=License)](https://github.com/Open-CMSIS-Pack/csolution-examples/blob/main/LICENSE-BSD-3-Clause)
 [![Hello: Test Build and Execution test](https://img.shields.io/github/actions/workflow/status/Open-CMSIS-Pack/csolution-examples/Hello-CI.yml?logo=arm&logoColor=0091bd&label=Hello:%20Test%20Build%20and%20Execution)](/.github/workflows/Hello-CI.yml)
 [![DualCore: Test Build](https://img.shields.io/github/actions/workflow/status/Open-CMSIS-Pack/csolution-examples/DualCore-CI.yml?logo=arm&logoColor=0091bd&label=DualCore:%20Test%20Build)](/.github/workflows/DualCore-CI.yml)
 [![CubeMX: Test Build](https://img.shields.io/github/actions/workflow/status/Open-CMSIS-Pack/csolution-examples/CubeMX-CI.yml?logo=arm&logoColor=0091bd&label=CubeMX:%20Test%20and%20Build)](/.github/workflows/CubeMX-CI.yml)
@@ -11,7 +11,7 @@ This is a collection of [CMSIS-Toolbox](https://open-cmsis-pack.github.io/cmsis-
 
 ## Tool Requirements
 
-The examples use **CMSIS-Toolbox 2.6.0** or higher and require additional tools such as CMake, Ninja, Arm Compiler 6, GCC Compiler, and Arm Fixed Virtual Platforms (AVH-FVP).
+The examples use **CMSIS-Toolbox 2.13.0** or higher and require additional tools such as CMake, Ninja, Arm Compiler 6, GCC Compiler, and Arm Fixed Virtual Platforms (AVH-FVP).
 
 Refer to [**Installation of the CMSIS-Toolbox**](https://open-cmsis-pack.github.io/cmsis-toolbox/installation) for information on the setup of a development environment with these tools.
 

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -7,12 +7,12 @@
     }
   ],
   "requires": {
-    "arm:tools/open-cmsis-pack/cmsis-toolbox": "^2.9.0",
+    "arm:tools/open-cmsis-pack/cmsis-toolbox": "^2.13.0",
     "arm:tools/kitware/cmake": "^3.31.5",
-    "arm:tools/ninja-build/ninja": "^1.12.0",
+    "arm:tools/ninja-build/ninja": "^1.13.2",
     "arm:compilers/arm/armclang": "^6.24.0",
     "arm:compilers/arm/arm-none-eabi-gcc": "^14.2.1",
     "arm:compilers/arm/llvm-embedded": "^20.1.0",
-    "arm:models/arm/avh-fvp": "^11.28.32"
+    "arm:models/arm/avh-fvp": "^11.31.28"
   }
 }


### PR DESCRIPTION
Added GitHub actions/setup-python@v6 for using the avh-fvp models version 11.31.28 in workflows Hello-CI.yml and SimpleTZ-CI.yml.
- Updated the minimum tool versions in vcpkg-configuration.json files. 
- Updated badges in README.md file