### PR TITLE
Adding default target-set

### DIFF
--- a/SimpleTrustZone/SimpleTZ.csolution.yml
+++ b/SimpleTrustZone/SimpleTZ.csolution.yml
@@ -1,5 +1,5 @@
 solution:
-  created-for: CMSIS-Toolbox@2.6.0
+  created-for: CMSIS-Toolbox@2.12.0
   cdefault:
   select-compiler:
     - compiler: AC6
@@ -15,6 +15,16 @@ solution:
   target-types:
     - type: AVH
       device: ARM::ARMCM33
+      target-set:
+        - set:
+          images:
+            - project-context: CM33_ns.Debug
+            - project-context: CM33_s.Debug
+          debugger:
+            name: Arm-FVP
+            model: FVP_MPS2_Cortex-M33
+            config-file: ../FVP/FVP_MPS2_Cortex-M33/fvp_config.txt
+            args: --stat
 
   build-types:
     - type: Debug

--- a/SimpleTrustZone/SimpleTZ.csolution.yml
+++ b/SimpleTrustZone/SimpleTZ.csolution.yml
@@ -35,5 +35,5 @@ solution:
       optimize: balanced
 
   projects:
-    - project: ./CM33_s/CM33_s.cproject.yml
     - project: ./CM33_ns/CM33_ns.cproject.yml
+    - project: ./CM33_s/CM33_s.cproject.yml


### PR DESCRIPTION
The default target-set 
- selects both secure and none-secure projects
- configures the FVP model to run application via play button